### PR TITLE
Catch errors when trying to remove keys that don't exist in iOS.

### DIFF
--- a/secure-storage.ios.ts
+++ b/secure-storage.ios.ts
@@ -140,19 +140,21 @@ export class SecureStorage implements SecureStorageApi {
         return;
       }
 
-      try {
-        let allAccounts = SAMKeychain.allAccounts();
-        for (let i = 0; i < allAccounts.count; i++) {
-          let key = allAccounts[i].objectForKey(SecureStorage.kSSKeychainAccountKey_copy);
+      let allAccounts = SAMKeychain.allAccounts();
+      for (let i = 0; i < allAccounts.count; i++) {
+        let key = allAccounts[i].objectForKey(SecureStorage.kSSKeychainAccountKey_copy);
+        try {
+          // console.log("SecureStorage: remove key -> " + key);
           let query = SAMKeychainQuery.new();
           query.service = arg && arg.service ? arg.service : SecureStorage.defaultService;
           query.account = key;
           query.deleteItem();
         }
-        resolve(true);
-      } catch (e) {
-        resolve(false);
+        catch (e) {
+          console.log("SecureStorage: Could not remove key -> " + key);
+        }
       }
+      resolve(true);
     });
   }
 
@@ -164,19 +166,21 @@ export class SecureStorage implements SecureStorageApi {
       return true;
     }
 
-    try {
-      let allAccounts = SAMKeychain.allAccounts();
-      for (let i = 0; i < allAccounts.count; i++) {
-        let key = allAccounts[i].objectForKey(SecureStorage.kSSKeychainAccountKey_copy);
+    let allAccounts = SAMKeychain.allAccounts();
+    for (let i = 0; i < allAccounts.count; i++) {
+      let key = allAccounts[i].objectForKey(SecureStorage.kSSKeychainAccountKey_copy);
+      try {
+        // console.log("SecureStorage: remove key -> " + key);
         let query = SAMKeychainQuery.new();
         query.service = arg && arg.service ? arg.service : SecureStorage.defaultService;
         query.account = key;
         query.deleteItem();
       }
-      return true;
-    } catch (e) {
-      return false;
+      catch (e) {
+        console.log("SecureStorage: Could not remove key -> " + key);
+      }
     }
+    return true;
   }
 
 }


### PR DESCRIPTION
In our app this section of code was silently failing when trying to remove a non existing key.  We wrapped the delete portion into a try catch and ignore the keys that don't exist. 