### PR TITLE
Add option to disable fallback to NSUserDefaults on iOS Simulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ declare const kSecAttrAccessibleWhenUnlockedThisDeviceOnly; // This is needed in
 const secureStorage = new SecureStorage(kSecAttrAccessibleWhenUnlockedThisDeviceOnly);
 ```
 
+## iOS Simulator
+
+Currently this plugin defaults to using `NSUserDefaults` on **iOS Simulators**. You can change this behaviour by providing `disableFallbackToUserDefaults` the constructor of `SecureStorage`. This then uses the keychain instead of `NSUserDefaults` on simulators.
+
+If you're running into issues similar to [Issue_10](https://github.com/EddyVerbruggen/nativescript-secure-storage/issues/10) consider using the default behaviour again.
+
 ## Credits
 * On __iOS__ we're leveraging the KeyChain using the [SAMKeychain](https://github.com/soffes/SAMKeychain) library (on the Simulator `NSUserDefaults`),
 * On __Android__ we're using [Hawk](https://github.com/orhanobut/hawk) library which internally uses [Facebook conceal](https://github.com/facebook/conceal).

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-secure-storage",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Secure Storage NativeScript plugin",
   "main": "secure-storage",
   "typings": "index.d.ts",

--- a/src/secure-storage.ios.ts
+++ b/src/secure-storage.ios.ts
@@ -17,14 +17,26 @@ export class SecureStorage extends SecureStorageCommon {
   // This is a copy of 'kSSKeychainAccountKey_copy' which is not exposed from SSKeychain.h by {N}
   private static kSSKeychainAccountKey_copy: string = "acct";
 
-  constructor(accessibilityType: string = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly) {
+  constructor(
+    accessibilityType: string = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+    disableFallbackToUserDefaults = false
+  ) {
     super();
-    const isMinIOS9 = NSProcessInfo.processInfo.isOperatingSystemAtLeastVersion({majorVersion: 9, minorVersion: 0, patchVersion: 0});
-    if (isMinIOS9) {
-      const simDeviceName = NSProcessInfo.processInfo.environment.objectForKey("SIMULATOR_DEVICE_NAME");
-      this.isSimulator = simDeviceName !== null;
+    if (disableFallbackToUserDefaults) {
+      this.isSimulator = false;
     } else {
-      this.isSimulator = UIDevice.currentDevice.name.toLowerCase().indexOf("simulator") > -1;
+      const isMinIOS9 = NSProcessInfo.processInfo.isOperatingSystemAtLeastVersion(
+        { majorVersion: 9, minorVersion: 0, patchVersion: 0 }
+      );
+      if (isMinIOS9) {
+        const simDeviceName = NSProcessInfo.processInfo.environment.objectForKey(
+          "SIMULATOR_DEVICE_NAME"
+        );
+        this.isSimulator = simDeviceName !== null;
+      } else {
+        this.isSimulator =
+          UIDevice.currentDevice.name.toLowerCase().indexOf("simulator") > -1;
+      }
     }
 
     this.accessibilityType = accessibilityType;


### PR DESCRIPTION
Adds an `disableFallbackToUserDefaults` option to the `SecureStorage` constructor to use the iOS Keychain on iOS Simulators.