### PR TITLE
Add access group

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,3 +266,39 @@ If you're running into issues similar to [issue_10](https://github.com/EddyVerbr
 * On __iOS__ we're leveraging the KeyChain using the [SAMKeychain](https://github.com/soffes/SAMKeychain) library (on the Simulator `NSUserDefaults`),
 * On __Android__ we're using [Hawk](https://github.com/orhanobut/hawk) library which internally uses [Facebook conceal](https://github.com/facebook/conceal).
 * Thanks, [Prabu Devarrajan](https://github.com/prabudevarrajan) for [adding the `deleteAll` function](https://github.com/EddyVerbruggen/nativescript-secure-storage/pull/11)!
+
+## iOS Keychain Access Groups
+
+You can share secrets between apps/extensions via Keychain access groups.
+
+To setup:
+
+* Add a keychain access group entitlement to your app
+  by adding an entry in the ```app/App_Resources/iOS/<someName>.entitlements``` file.
+
+  e.g.
+  ```xml
+  <key>keychain-access-groups</key>
+  <array>
+    <string>$(AppIdentifierPrefix)com.my.app.sharedgroup</string>
+  </array>
+  ```
+* Then in your app specify the ```accessGroup``` property when getting/setting values.
+  e.g. 
+  
+  ```typescript
+  import { SecureStorage } from "nativescript-secure-storage";
+
+  export class MyComponent {
+    secureStorage = new SecureStorage();
+
+    // a method that can be called from your view
+    setSecureValue() {
+      this.secureStorage.set({
+        accessGroup:"<TeamID>.com.my.app.sharedgroup",
+        key: 'myKey',
+        value: 'my value'
+      }).then(success => { console.log(success)});
+    }
+  }
+  ```

--- a/src/secure-storage.common.ts
+++ b/src/secure-storage.common.ts
@@ -1,17 +1,20 @@
 import { ApplicationSettings } from "@nativescript/core";
 
 export interface SetOptions {
+  accessGroup?: string;
   service?: string;
   key: string;
   value: string;
 }
 
 export interface GetOptions {
+  accessGroup?: string;
   service?: string;
   key: string;
 }
 
 export interface RemoveOptions {
+  accessGroup?: string;
   service?: string;
   key: string;
 }

--- a/src/secure-storage.ios.ts
+++ b/src/secure-storage.ios.ts
@@ -46,7 +46,7 @@ export class SecureStorage extends SecureStorageCommon {
       let query = SAMKeychainQuery.new();
       query.service = arg.service || SecureStorage.defaultService;
       query.account = arg.key;
-      if(arg.accessGroup){
+      if (arg.accessGroup) {
         query.accessGroup = arg.accessGroup;
       }
       try {
@@ -66,7 +66,7 @@ export class SecureStorage extends SecureStorageCommon {
     let query = SAMKeychainQuery.new();
     query.service = arg.service || SecureStorage.defaultService;
     query.account = arg.key;
-    if(arg.accessGroup){
+    if (arg.accessGroup) {
       query.accessGroup = arg.accessGroup;
     }
     try {
@@ -90,7 +90,7 @@ export class SecureStorage extends SecureStorageCommon {
       query.service = arg.service || SecureStorage.defaultService;
       query.account = arg.key;
       query.password = arg.value;
-      if(arg.accessGroup){
+      if (arg.accessGroup) {
         query.accessGroup = arg.accessGroup;
       }
       resolve(query.save());
@@ -108,7 +108,7 @@ export class SecureStorage extends SecureStorageCommon {
     query.service = arg.service || SecureStorage.defaultService;
     query.account = arg.key;
     query.password = arg.value;
-    if(arg.accessGroup){
+    if (arg.accessGroup) {
       query.accessGroup = arg.accessGroup;
     }
     return query.save();
@@ -125,7 +125,7 @@ export class SecureStorage extends SecureStorageCommon {
       let query = SAMKeychainQuery.new();
       query.service = arg.service || SecureStorage.defaultService;
       query.account = arg.key;
-      if(arg.accessGroup){
+      if (arg.accessGroup) {
         query.accessGroup = arg.accessGroup;
       }
       try {
@@ -145,7 +145,7 @@ export class SecureStorage extends SecureStorageCommon {
     let query = SAMKeychainQuery.new();
     query.service = arg.service || SecureStorage.defaultService;
     query.account = arg.key;
-    if(arg.accessGroup){
+    if (arg.accessGroup) {
       query.accessGroup = arg.accessGroup;
     }
     try {

--- a/src/secure-storage.ios.ts
+++ b/src/secure-storage.ios.ts
@@ -46,7 +46,9 @@ export class SecureStorage extends SecureStorageCommon {
       let query = SAMKeychainQuery.new();
       query.service = arg.service || SecureStorage.defaultService;
       query.account = arg.key;
-
+      if(arg.accessGroup){
+        query.accessGroup = arg.accessGroup;
+      }
       try {
         query.fetch();
         resolve(query.password);
@@ -64,6 +66,9 @@ export class SecureStorage extends SecureStorageCommon {
     let query = SAMKeychainQuery.new();
     query.service = arg.service || SecureStorage.defaultService;
     query.account = arg.key;
+    if(arg.accessGroup){
+      query.accessGroup = arg.accessGroup;
+    }
     try {
       query.fetch();
       return query.password;
@@ -85,6 +90,9 @@ export class SecureStorage extends SecureStorageCommon {
       query.service = arg.service || SecureStorage.defaultService;
       query.account = arg.key;
       query.password = arg.value;
+      if(arg.accessGroup){
+        query.accessGroup = arg.accessGroup;
+      }
       resolve(query.save());
     });
   }
@@ -100,6 +108,9 @@ export class SecureStorage extends SecureStorageCommon {
     query.service = arg.service || SecureStorage.defaultService;
     query.account = arg.key;
     query.password = arg.value;
+    if(arg.accessGroup){
+      query.accessGroup = arg.accessGroup;
+    }
     return query.save();
   }
 
@@ -114,6 +125,9 @@ export class SecureStorage extends SecureStorageCommon {
       let query = SAMKeychainQuery.new();
       query.service = arg.service || SecureStorage.defaultService;
       query.account = arg.key;
+      if(arg.accessGroup){
+        query.accessGroup = arg.accessGroup;
+      }
       try {
         resolve(query.deleteItem());
       } catch (e) {
@@ -131,6 +145,9 @@ export class SecureStorage extends SecureStorageCommon {
     let query = SAMKeychainQuery.new();
     query.service = arg.service || SecureStorage.defaultService;
     query.account = arg.key;
+    if(arg.accessGroup){
+      query.accessGroup = arg.accessGroup;
+    }
     try {
       return query.deleteItem();
     } catch (e) {


### PR DESCRIPTION
Expose the accessGroup property to allow IOS apps to share secrets with other apps/widgets etc. via a keychain group.